### PR TITLE
Make the before-CSS hide footnote(s) by default.

### DIFF
--- a/css/dist/ReadiumCSS-before.css
+++ b/css/dist/ReadiumCSS-before.css
@@ -108,6 +108,13 @@ h1, h2, h3 {
   line-break: strict;
 }
 
+/* Hide footnotes by default */
+
+aside[epub|type^="footnote"],
+aside[epub\:type^="footnote"] {
+  display: none;
+}
+
 /* Set default font for Math */
 
 math {

--- a/css/dist/cjk-horizontal/ReadiumCSS-before.css
+++ b/css/dist/cjk-horizontal/ReadiumCSS-before.css
@@ -108,6 +108,13 @@ h1, h2, h3 {
   line-break: strict;
 }
 
+/* Hide footnotes by default */
+
+aside[epub|type^="footnote"],
+aside[epub\:type^="footnote"] {
+  display: none;
+}
+
 /* Set default font for Math */
 
 math {

--- a/css/dist/cjk-vertical/ReadiumCSS-before.css
+++ b/css/dist/cjk-vertical/ReadiumCSS-before.css
@@ -108,6 +108,13 @@ h1, h2, h3 {
   line-break: strict;
 }
 
+/* Hide footnotes by default */
+
+aside[epub|type^="footnote"],
+aside[epub\:type^="footnote"] {
+  display: none;
+}
+
 /* Set default font for Math */
 
 math {

--- a/css/dist/rtl/ReadiumCSS-before.css
+++ b/css/dist/rtl/ReadiumCSS-before.css
@@ -108,6 +108,13 @@ h1, h2, h3 {
   line-break: strict;
 }
 
+/* Hide footnotes by default */
+
+aside[epub|type^="footnote"],
+aside[epub\:type^="footnote"] {
+  display: none;
+}
+
 /* Set default font for Math */
 
 math {

--- a/css/src/modules/ReadiumCSS-base.css
+++ b/css/src/modules/ReadiumCSS-base.css
@@ -61,6 +61,13 @@ h1, h2, h3 {
   line-break: strict;
 }
 
+/* Hide footnotes by default */
+
+aside[epub|type^="footnote"],
+aside[epub\:type^="footnote"] {
+  display: none;
+}
+
 /* Set default font for Math */
 
 math {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "readium-css",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] I’ve read [contributing guidelines](../contributing.md)
- [x] I’ve signed and sent the [Readium ICLA](http://readium.github.io/documents/Individual%20Contributor%20License%20Agreement.pdf) (no need if your PR is about fixing typos)
- [x] I’m making this pull request against the develop branch
- [x] I’ve updated from the develop branch before proposing this pull request
- [x] I’ve tested the changes for bug fixes and/or features
- [x] I’ve documented new code

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, other)

Feature.

**What is the current behaviour?** (You can also link to an open issue here)

Elements matching `aside[epub|type^="footnote"]` are visible in the flow of text.

**What is the new behaviour?**

Based on the fact that these elements are meant to be shown via popups, they are now hidden in the flow of text.  The reading system will need to display them in response to the user tapping a hyperlink that would otherwise navigate to one of these elements (where that hyperlink matches `a[epub|type="noteref"]`).

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yes, books that displayed these `<aside>` elements in the flow of text will no longer display them by default.

Since this new CSS rule is in the "before" CSS, publication authors can choose to override it if desired.

Otherwise, the app using Readium CSS will need to support the detection of footnotes and display them in a popup.  Note that R2-Navigator for Android [already supports this](https://github.com/readium/r2-navigator-kotlin/blob/1b65c15cf7c52af12ee5bb90443e138c657f0af9/r2-navigator/src/main/java/org/readium/r2/navigator/R2BasicWebView.kt#L156).

**Other information:**

The same rules could be applied to `endnote(s)` and/or `rearnote(s)` but I have chosen not to as it makes more sense to include them in the flow of text, compared to footnotes, as they would fall at the end of a section (chapter, likely) and therefore not interrupt the reader in the same way as a footnote.

As I write the section above on breaking changes, and with https://github.com/readium/swift-toolkit/issues/139 in mind, I come to these thoughts:

- If Readium CSS hides these elements by default, it would follow that Readium Navigator shows popups for them by default.
- Conversely, if Readium Navigator will not have default support for pop-up footnotes, (as is being discussed/requested in the linked issue) then it seems we have a weak case for Readium CSS hiding them by default.
- Even if Readium Navigator does not have a default implementation for displaying pop-up notes, it could have a protocol/interface that requires this in the host app.  Seems...not very batteries-included, but it's certainly an approach.

Let's discuss!