### PR TITLE
Fix japanese font settings

### DIFF
--- a/css/src/ReadiumCSS-ebpaj_fonts_patch.css
+++ b/css/src/ReadiumCSS-ebpaj_fonts_patch.css
@@ -29,12 +29,12 @@
 @font-face {
   font-family: "serif-ja";
   src: local("ＭＳ Ｐ明朝"), /* for IE */
-  local("MS PMincho"), /* ＭＳ Ｐ明朝 */
-  local("HiraMinProN-W3"), local("Hiragino Mincho ProN"), /* ヒラギノ明朝 ProN W3 */
-  local("HiraMinPro-W3"), local("Hiragino Mincho Pro"), /* ヒラギノ明朝 Pro W3 */
-  local("YuMin-Medium"), local("YuMincho"), /* 游明朝体(macOS) */
-  local("Yu Mincho"), /* 游明朝(Windows) */
-  local("BIZ UDPMincho"); /* BIZ UDP明朝 */
+      local("MS PMincho"), /* ＭＳ Ｐ明朝 */
+      local("HiraMinProN-W3"), local("Hiragino Mincho ProN"), /* ヒラギノ明朝 ProN W3 */
+      local("HiraMinPro-W3"), local("Hiragino Mincho Pro"), /* ヒラギノ明朝 Pro W3 */
+      local("YuMin-Medium"), local("YuMincho"), /* 游明朝体(macOS) */
+      local("Yu Mincho"), /* 游明朝(Windows) */
+      local("BIZ UDPMincho"); /* BIZ UDP明朝 */
 }
 
 @font-face {
@@ -60,7 +60,6 @@
        local("HiraMinProN-W3"), local("Hiragino Mincho ProN"), /* ヒラギノ明朝 ProN W3 */
        local("HiraMinPro-W3"), local("Hiragino Mincho Pro"), /* ヒラギノ明朝 Pro W3 */
        local("YuMin-Medium"), local("YuMincho"), /* 游明朝体(macOS) */
-       local("Yu Mincho"), /* 游明朝(Windows) */
        local("Yu Mincho"), /* 游明朝(Windows) */
        local("BIZ UDMincho"); /*  BIZ UD明朝 */
 }

--- a/css/src/ReadiumCSS-ebpaj_fonts_patch.css
+++ b/css/src/ReadiumCSS-ebpaj_fonts_patch.css
@@ -19,62 +19,62 @@
      <meta property="ebpaj:guide-version">1.1</meta>
 */
 
+/* 
+   Hiragino PostScript Font name lists:
+   https://www.screen.co.jp/ga_product/sento/support/QA/ss_psname.html
+*/
+
 /* 横組み用 (horizontal writing) */
 
 @font-face {
   font-family: "serif-ja";
-  src: local("ＭＳ Ｐ明朝"),
-       local("MS PMincho"),
-       local("Hiragino Mincho Pro"),
-       local("ヒラギノ明朝 Pro W3"),
-       local("游明朝"),
-       local("YuMincho"),
-       local("ＭＳ 明朝"),
-       local("MS Mincho"),
-       local("Hiragino Mincho ProN");
+  src: local("ＭＳ Ｐ明朝"), /* for IE */
+  local("MS PMincho"), /* ＭＳ Ｐ明朝 */
+  local("HiraMinProN-W3"), local("Hiragino Mincho ProN"), /* ヒラギノ明朝 ProN W3 */
+  local("HiraMinPro-W3"), local("Hiragino Mincho Pro"), /* ヒラギノ明朝 Pro W3 */
+  local("YuMin-Medium"), local("YuMincho"), /* 游明朝体(macOS) */
+  local("Yu Mincho"), /* 游明朝(Windows) */
+  local("BIZ UDPMincho"); /* BIZ UDP明朝 */
 }
 
 @font-face {
   font-family: "sans-serif-ja";
-  src: local("ＭＳ Ｐゴシック"),
-       local("MS PGothic"),
-       local("Hiragino Kaku Gothic Pro W3"),
-       local("ヒラギノ角ゴ Pro W3"),
-       local("Hiragino Sans GB"),
-       local("ヒラギノ角ゴシック W3"),
-       local("游ゴシック"),
-       local("YuGothic"),
-       local("ＭＳ ゴシック"),
-       local("MS Gothic"),
-       local("Hiragino Sans");
+  src: local("ＭＳ Ｐゴシック"), /* for IE */
+       local("MS PGothic"), /* ＭＳ Ｐゴシック */
+       local("HiraginoSans-W3"), local("Hiragino Sans"), /* ヒラギノ角ゴシック */
+       local("HiraKakuProN-W3"), local("Hiragino Kaku Gothic ProN"), /* ヒラギノ角ゴ ProN W3 */
+       local("HiraKakuPro-W3"), local("Hiragino Kaku Gothic Pro"), /* ヒラギノ角ゴ Pro W3 */
+       local("ヒラギノ角ゴ W3"), /* for old  Safari */
+       local("HiraginoKaku-W3-90msp-RKSJ-H"), /* ヒラギノ角ゴ W3(TrueType) */
+       local("YuGothic-Medium"), local("YuGothic"), /* 游ゴシック体(macOS) */
+       local("Yu Gothic"), /* 游ゴシック(Windows) */
+       local("BIZ UDPGothic"); /* BIZ UDPゴシック */
 }
 
 /* 縦組み用 (vertical writing) */
 
 @font-face {
   font-family: "serif-ja-v";
-  src: local("ＭＳ 明朝"),
-       local("MS Mincho"),
-       local("Hiragino Mincho Pro"),
-       local("ヒラギノ明朝 Pro W3"),
-       local("游明朝"),
-       local("YuMincho"),
-       local("ＭＳ Ｐ明朝"),
-       local("MS PMincho"),
-       local("Hiragino Mincho ProN");
+  src: local("ＭＳ 明朝"), /* for IE */
+       local("MS Mincho"), /* ＭＳ 明朝 */
+       local("HiraMinProN-W3"), local("Hiragino Mincho ProN"), /* ヒラギノ明朝 ProN W3 */
+       local("HiraMinPro-W3"), local("Hiragino Mincho Pro"), /* ヒラギノ明朝 Pro W3 */
+       local("YuMin-Medium"), local("YuMincho"), /* 游明朝体(macOS) */
+       local("Yu Mincho"), /* 游明朝(Windows) */
+       local("Yu Mincho"), /* 游明朝(Windows) */
+       local("BIZ UDMincho"); /*  BIZ UD明朝 */
 }
 
 @font-face {
   font-family: "sans-serif-ja-v";
-  src: local("ＭＳ ゴシック"),
-       local("MS Gothic"),
-       local("Hiragino Kaku Gothic Pro W3"),
-       local("ヒラギノ角ゴ Pro W3"),
-       local("Hiragino Sans GB"),
-       local("ヒラギノ角ゴシック W3"),
-       local("游ゴシック"),
-       local("YuGothic"),
-       local("ＭＳ Ｐゴシック"),
-       local("MS PGothic"),
-       local("Hiragino Sans");
+  src: local("ＭＳ ゴシック"), /* for IE */
+       local("MS Gothic"), /* ＭＳ ゴシック */
+       local("HiraginoSans-W3"), local("Hiragino Sans"), /* ヒラギノ角ゴシック */
+       local("HiraKakuProN-W3"), local("Hiragino Kaku Gothic ProN"), /* ヒラギノ角ゴ ProN W3 */
+       local("HiraKakuPro-W3"), local("Hiragino Kaku Gothic Pro"), /* ヒラギノ角ゴ Pro W3 */
+       local("ヒラギノ角ゴ W3"), /* for old Safari */
+       local("HiraKakuDS-W3-83pv-RKSJ-H"), /* ヒラギノ角ゴ W3(TrueType) */
+       local("YuGothic-Medium"), local("YuGothic"), /* 游ゴシック体(macOS) */
+       local("Yu Gothic"), /* 游ゴシック(Windows) */
+       local("BIZ UDGothic"); /* BIZ UDゴシック */
 }

--- a/css/src/ReadiumCSS-ebpaj_fonts_patch.css
+++ b/css/src/ReadiumCSS-ebpaj_fonts_patch.css
@@ -47,7 +47,7 @@
        local("ヒラギノ角ゴ W3"), /* for old  Safari */
        local("HiraginoKaku-W3-90msp-RKSJ-H"), /* ヒラギノ角ゴ W3(TrueType) */
        local("YuGothic-Medium"), local("YuGothic"), /* 游ゴシック体(macOS) */
-       local("Yu Gothic"), /* 游ゴシック(Windows) */
+       local("Yu Gothic Medium"), local("Yu Gothic"), /* 游ゴシック(Windows) "Yu Gothic" is a fallback. */
        local("BIZ UDPGothic"); /* BIZ UDPゴシック */
 }
 
@@ -74,6 +74,6 @@
        local("ヒラギノ角ゴ W3"), /* for old Safari */
        local("HiraKakuDS-W3-83pv-RKSJ-H"), /* ヒラギノ角ゴ W3(TrueType) */
        local("YuGothic-Medium"), local("YuGothic"), /* 游ゴシック体(macOS) */
-       local("Yu Gothic"), /* 游ゴシック(Windows) */
+       local("Yu Gothic Medium"), local("Yu Gothic"), /* 游ゴシック(Windows)  "Yu Gothic" is a fallback. */
        local("BIZ UDGothic"); /* BIZ UDゴシック */
 }

--- a/css/src/modules/ReadiumCSS-base.css
+++ b/css/src/modules/ReadiumCSS-base.css
@@ -123,11 +123,11 @@ math {
   --RS__lineHeightCompensation: 1.167;
 
   /* Extra variables for Japanese font-stacks as we may want to reuse them for user settings + default */
-  /* BIZ UD fonts will work on Windows. If you set half-width (ASCII) characters to `upright` using `text-orientation`, the width of these characters remains narrow. In this case, specify `font-variant-east-asian: full-width;` as well. */
+  /* This setting uses the BIZ UD font for serif and the Yu font for sans serif on Windows. Note: When using the BIZ UD font for vertical writing display, if you set half-width (ASCII) characters to stand upright with `text-orientation: upright`, the width of these characters is narrow. By specifying `font-variant-east-asian: full-width;` at the same time, you can display the characters with the width of one full-width character. */
   --RS__serif-ja: "Hiragino Mincho ProN", "Hiragino Mincho Pro", "YuMincho", "BIZ UDPMincho", "Yu Mincho", "ＭＳ Ｐ明朝", "MS PMincho", serif;
-  --RS__sans-serif-ja: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "ヒラギノ角ゴ W3", "YuGothic", "BIZ UDPGothic", "Yu Gothic", "ＭＳ Ｐゴシック", "MS PGothic", sans-serif;
+  --RS__sans-serif-ja: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "ヒラギノ角ゴ W3", "YuGothic", "Yu Gothic Medium", "BIZ UDPGothic", "Yu Gothic", "ＭＳ Ｐゴシック", "MS PGothic", sans-serif;
   --RS__serif-ja-v: "Hiragino Mincho ProN", "Hiragino Mincho Pro", "YuMincho", "BIZ UDMincho", "Yu Mincho", "ＭＳ明朝", "MS Mincho", serif;
-  --RS__sans-serif-ja-v: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "ヒラギノ角ゴ W3", "YuGothic", "BIZ UDGothic", "Yu Gothic", "ＭＳゴシック", "MS Gothic", sans-serif;
+  --RS__sans-serif-ja-v: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "ヒラギノ角ゴ W3", "YuGothic", "Yu Gothic Medium", "BIZ UDGothic", "Yu Gothic", "ＭＳゴシック", "MS Gothic", sans-serif;
 }
 
 :lang(km) {

--- a/css/src/modules/ReadiumCSS-base.css
+++ b/css/src/modules/ReadiumCSS-base.css
@@ -126,7 +126,7 @@ math {
   /* BIZ UD fonts will work on Windows. If you set half-width (ASCII) characters to `upright` using `text-orientation`, the width of these characters remains narrow. In this case, specify `font-variant-east-asian: full-width;` as well. */
   --RS__serif-ja: "Hiragino Mincho ProN", "Hiragino Mincho Pro", "YuMincho", "BIZ UDPMincho", "Yu Mincho", "ＭＳ Ｐ明朝", "MS PMincho", serif;
   --RS__sans-serif-ja: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "ヒラギノ角ゴ W3", "YuGothic", "BIZ UDPGothic", "Yu Gothic", "ＭＳ Ｐゴシック", "MS PGothic", sans-serif;
-  --RS__serif-ja-v: "Hiragino Mincho ProN", "Hiragino Mincho Pro", "YuMincho", "BIZ UDPMincho", "Yu Mincho", "ＭＳ明朝", "MS Mincho", serif;
+  --RS__serif-ja-v: "Hiragino Mincho ProN", "Hiragino Mincho Pro", "YuMincho", "BIZ UDMincho", "Yu Mincho", "ＭＳ明朝", "MS Mincho", serif;
   --RS__sans-serif-ja-v: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "ヒラギノ角ゴ W3", "YuGothic", "BIZ UDGothic", "Yu Gothic", "ＭＳゴシック", "MS Gothic", sans-serif;
 }
 

--- a/css/src/modules/ReadiumCSS-base.css
+++ b/css/src/modules/ReadiumCSS-base.css
@@ -117,16 +117,17 @@ math {
 }
 
 :lang(ja) {
-  --RS__baseFontFamily: "游ゴシック体", YuGothic, "ヒラギノ丸ゴ", "Hiragino Sans", "Yu Gothic UI", "Meiryo UI", "MS Gothic", Roboto, Noto, "Noto Sans CJK JP", sans-serif;
+  --RS__baseFontFamily: YuGothic, "Hiragino Maru Gothic ProN", "Hiragino Sans", "Yu Gothic UI", "Meiryo UI", "MS Gothic", Roboto, Noto, "Noto Sans CJK JP", sans-serif;
 
   /* For CJK, the line-height is usually 15–20% more than for Latin */
   --RS__lineHeightCompensation: 1.167;
 
   /* Extra variables for Japanese font-stacks as we may want to reuse them for user settings + default */
-  --RS__serif-ja: "ＭＳ Ｐ明朝", "MS PMincho", "Hiragino Mincho Pro", "ヒラギノ明朝 Pro W3", "游明朝", "YuMincho", "ＭＳ 明朝", "MS Mincho", "Hiragino Mincho ProN", serif;
-  --RS__sans-serif-ja: "ＭＳ Ｐゴシック", "MS PGothic", "Hiragino Kaku Gothic Pro W3", "ヒラギノ角ゴ Pro W3", "Hiragino Sans GB", "ヒラギノ角ゴシック W3", "游ゴシック", "YuGothic", "ＭＳ ゴシック", "MS Gothic", "Hiragino Sans", sans-serif;
-  --RS__serif-ja-v: "ＭＳ 明朝", "MS Mincho", "Hiragino Mincho Pro", "ヒラギノ明朝 Pro W3", "游明朝", "YuMincho", "ＭＳ Ｐ明朝", "MS PMincho", "Hiragino Mincho ProN", serif;
-  --RS__sans-serif-ja-v: "ＭＳ ゴシック", "MS Gothic", "Hiragino Kaku Gothic Pro W3", "ヒラギノ角ゴ Pro W3", "Hiragino Sans GB", "ヒラギノ角ゴシック W3", "游ゴシック", "YuGothic", "ＭＳ Ｐゴシック", "MS PGothic", "Hiragino Sans", sans-serif;
+  /* BIZ UD fonts will work on Windows. If you set half-width (ASCII) characters to `upright` using `text-orientation`, the width of these characters remains narrow. In this case, specify `font-variant-east-asian: full-width;` as well. */
+  --RS__serif-ja: "Hiragino Mincho ProN", "Hiragino Mincho Pro", "YuMincho", "BIZ UDPMincho", "Yu Mincho", "ＭＳ Ｐ明朝", "MS PMincho", serif;
+  --RS__sans-serif-ja: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "ヒラギノ角ゴ W3", "YuGothic", "BIZ UDPGothic", "Yu Gothic", "ＭＳ Ｐゴシック", "MS PGothic", sans-serif;
+  --RS__serif-ja-v: "Hiragino Mincho ProN", "Hiragino Mincho Pro", "YuMincho", "BIZ UDPMincho", "Yu Mincho", "ＭＳ明朝", "MS Mincho", serif;
+  --RS__sans-serif-ja-v: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "ヒラギノ角ゴ W3", "YuGothic", "BIZ UDGothic", "Yu Gothic", "ＭＳゴシック", "MS Gothic", sans-serif;
 }
 
 :lang(km) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] I've read [contributing guidelines](../contributing.md)
- [x] I'm making this pull request against the develop branch
- [x] I've updated from the develop branch before proposing this pull request
- [x] I've tested the changes for bug fixes and/or features
- [x] I've documented new code

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, other)

In a Japanese Windows environment in Thorium Reader, I will change the font-family to be applied preferentially from MS Font to BIZ UD font.

To do this, I did the following:

- css/src/ReadiumCSS-ebpaj_fonts_patch.css
    - Simply adding the BIZ UD font to the four font settings in "Extra variables for Japanese font-stacks" in ReadiumCSS-base.css did not work in Thorium Reader, so I added the BIZ UD font to `@font-face` in this file.
    - There are Japanese and English settings in `@font-face` in this file, but the Japanese setting is necessary for older environments such as Internet Explorer and should not be necessary in modern environments. Therefore, I removed as many settings with font names using Japanese as possible.
    - In addition, I set the Postscript name that should originally be written in local(), and the English font name to ensure recognition by the browser engine.
    - Even when setting a serif font, the sans serif font of MS font was also set as a fallback, so I removed it. I did not understand the need for fallback for fonts that are not the same typeface. The same shape was obtained in the reverse case, so I removed it in the same way.
    - I was not sure how much of an impact changing the order of the local in the src property would have, so I made some fine adjustments while leaving the MS font at the top as before.
- css/src/modules/ReadiumCSS-base.css
    - I removed the Japanese names from the RS__baseFontFamily settings and only used the English names. I thought it would probably be okay.
    - I changed the order of priority settings for each font in "Extra variables for Japanese font-stacks" so that the fonts to be applied to macOS are listed first, and then the fonts to be applied to Windows.
At that time, the priority order in the Windows settings was BIZ UD, Yu, and MS fonts. (All of these fonts are installed by default in recent Windows.)
    - I only set the Japanese font names for MS fonts and Hiragino in old macOS environments. The rest were set with English names.

**What is the current behaviour?** (You can also link to an open issue here)

When using the current Thorium Reader on Windows, if you apply each font in "Extra variables for Japanese font-stacks" in the text font settings that can be set after changing the UI language to "Japanese", it will become an MS font. MS fonts are a bit rough, so I think the reading experience using this font is a bit subtle.

ex. https://github.com/edrlab/thorium-reader/issues/2353#issue-2316639998

**What is the new behaviour?**

I changed the font name settings in various ways, but the behavior change should only apply to Windows. And in Thorium Reader, it should be displayed in BIZ UD font with anti-aliasing enabled.

ex. https://github.com/edrlab/thorium-reader/pull/2252#issuecomment-2130699644

(I haven't confirmed that Thorium works on macOS.)

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

I don't think it will be a problem in the app.

**Other information:**

Some people think that Yu fonts are better than BIZ UD fonts, so it's a bit difficult to decide whether to prioritize BIZ UD (BIZ UD has less space after punctuation marks). 
However, in this pull request, I chose the BIZ UD font, which is displayed clearly, because the default Yu font on Windows is displayed a little thin. 
Therefore, I may choose to change the priority font order in the future.

Example of Yu/BIZ UD display in Chrome browser (image attached): https://codepen.io/peaceroad/pen/dyEOVdr
![image](https://github.com/readium/readium-css/assets/1066782/83e12ab0-5949-4e72-a04e-dbf2fd058f94)

One thing to note in particular is that in vertical writing mode using the BIZ UD font, half-width ASCII characters are displayed narrowly, so if you look at only this part, the Yu font may be slightly easier to read. (Looking at this issue alone, it can be avoided by changing the setting from BIZ UD to BIZ UDP, but I didn't know if that was a good idea, so I didn't do that.)

Also, since I don't usually use macOS, there may be a better setting.