### PR TITLE
Submodule improvements

### DIFF
--- a/css/dist/ReadiumCSS-after.css
+++ b/css/dist/ReadiumCSS-after.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0-beta.20
+ * Readium CSS v.2.0.0-beta.21
  * Copyright (c) 2017–2025. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/ReadiumCSS-after.css
+++ b/css/dist/ReadiumCSS-after.css
@@ -272,9 +272,13 @@ body{
   font-weight:inherit !important;
 }
 
+:root[style*="AccessibleDfA"] body *:not(a),:root[style*="IA Writer Duospace"] body *:not(a),
+:root[style*="readium-a11y-on"] body *:not(a){
+  text-decoration:none !important;
+}
+
 :root[style*="AccessibleDfA"] body *,:root[style*="IA Writer Duospace"] body *,
 :root[style*="readium-a11y-on"] body *{
-  text-decoration:none !important;
   font-variant-caps:normal !important;
   font-variant-numeric:normal !important;
   font-variant-position:normal !important;
@@ -324,7 +328,7 @@ body{
   margin-bottom:var(--USER__paraSpacing) !important;
 }
 
-:root[style*="--USER__paraIndent"] p{
+:root[style*="--USER__paraIndent"] p:not([class*="title"]):not(blockquote p):not(figcaption p):not(header p):not(hgroup p):not(div:has(+ *) > h1 + p):not(div:has(+ *) > p:has(+ h1)){
   text-indent:var(--USER__paraIndent) !important;
 }
 

--- a/css/dist/ReadiumCSS-before.css
+++ b/css/dist/ReadiumCSS-before.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0-beta.20
+ * Readium CSS v.2.0.0-beta.21
  * Copyright (c) 2017–2025. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/ReadiumCSS-default.css
+++ b/css/dist/ReadiumCSS-default.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0-beta.20
+ * Readium CSS v.2.0.0-beta.21
  * Copyright (c) 2017–2025. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/cjk-horizontal/ReadiumCSS-after.css
+++ b/css/dist/cjk-horizontal/ReadiumCSS-after.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0-beta.20
+ * Readium CSS v.2.0.0-beta.21
  * Copyright (c) 2017–2025. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/cjk-horizontal/ReadiumCSS-before.css
+++ b/css/dist/cjk-horizontal/ReadiumCSS-before.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0-beta.20
+ * Readium CSS v.2.0.0-beta.21
  * Copyright (c) 2017–2025. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/cjk-horizontal/ReadiumCSS-default.css
+++ b/css/dist/cjk-horizontal/ReadiumCSS-default.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0-beta.20
+ * Readium CSS v.2.0.0-beta.21
  * Copyright (c) 2017–2025. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/cjk-vertical/ReadiumCSS-after.css
+++ b/css/dist/cjk-vertical/ReadiumCSS-after.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0-beta.20
+ * Readium CSS v.2.0.0-beta.21
  * Copyright (c) 2017–2025. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/cjk-vertical/ReadiumCSS-before.css
+++ b/css/dist/cjk-vertical/ReadiumCSS-before.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0-beta.20
+ * Readium CSS v.2.0.0-beta.21
  * Copyright (c) 2017–2025. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/cjk-vertical/ReadiumCSS-default.css
+++ b/css/dist/cjk-vertical/ReadiumCSS-default.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0-beta.20
+ * Readium CSS v.2.0.0-beta.21
  * Copyright (c) 2017–2025. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/rtl/ReadiumCSS-after.css
+++ b/css/dist/rtl/ReadiumCSS-after.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0-beta.20
+ * Readium CSS v.2.0.0-beta.21
  * Copyright (c) 2017–2025. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/rtl/ReadiumCSS-after.css
+++ b/css/dist/rtl/ReadiumCSS-after.css
@@ -266,7 +266,7 @@ body{
   margin-bottom:var(--USER__paraSpacing) !important;
 }
 
-:root[style*="--USER__paraIndent"] p{
+:root[style*="--USER__paraIndent"] p:not([class*="title"]):not(blockquote p):not(figcaption p):not(header p):not(hgroup p):not(div:has(+ *) > h1 + p):not(div:has(+ *) > p:has(+ h1)){
   text-indent:var(--USER__paraIndent) !important;
 }
 

--- a/css/dist/rtl/ReadiumCSS-before.css
+++ b/css/dist/rtl/ReadiumCSS-before.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0-beta.20
+ * Readium CSS v.2.0.0-beta.21
  * Copyright (c) 2017–2025. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/rtl/ReadiumCSS-default.css
+++ b/css/dist/rtl/ReadiumCSS-default.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0-beta.20
+ * Readium CSS v.2.0.0-beta.21
  * Copyright (c) 2017–2025. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/src/modules/user-settings-submodules/ReadiumCSS-a11yFont_pref.css
+++ b/css/src/modules/user-settings-submodules/ReadiumCSS-a11yFont_pref.css
@@ -34,15 +34,21 @@
   font-style: inherit !important;
 }
 
-/* Normalizing text-decoration, subs and sups */
+/* Normalizing text-decoration */
+:root:--a11y-font body *:not(a),
+:root:--a11y-normalize body *:not(a) {
+  text-decoration: none !important;
+}
+
+/* Normalizing font-variant */
 :root:--a11y-font body *,
 :root:--a11y-normalize body * {
-  text-decoration: none !important;
   font-variant-caps: normal !important;
   font-variant-position: normal !important;
   font-variant-numeric: normal !important;
 }
 
+/* Normalizing sup and sub */
 :root:--a11y-font sup,
 :root:--a11y-normalize sup,
 :root:--a11y-font sub,

--- a/css/src/modules/user-settings-submodules/ReadiumCSS-paraIndent_pref.css
+++ b/css/src/modules/user-settings-submodules/ReadiumCSS-paraIndent_pref.css
@@ -6,7 +6,7 @@
 
    Repo: https://github.com/readium/css */
 
-:root[style*="--USER__paraIndent"] p {
+:root[style*="--USER__paraIndent"] p:not([class*="title"]):not(blockquote p):not(figcaption p):not(header p):not(hgroup p):not(div:has(+ *) > h1 + p):not(div:has(+ *) > p:has(+ h1)) {
   text-indent: var(--USER__paraIndent) !important;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readium/css",
-  "version": "2.0.0-beta.19",
+  "version": "2.0.0-beta.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@readium/css",
-      "version": "2.0.0-beta.19",
+      "version": "2.0.0-beta.21",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@daltontan/postcss-import-json": "^1.1.1",
@@ -2908,33 +2908,33 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.1.tgz",
-      "integrity": "sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==",
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.43.1"
+        "playwright-core": "1.56.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.1.tgz",
-      "integrity": "sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==",
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/pngjs": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@readium/css",
   "description": "A set of reference stylesheets for EPUB Reading Systems",
-  "version": "2.0.0-beta.20",
+  "version": "2.0.0-beta.21",
   "homepage": "https://github.com/readium/css",
   "license": "BSD-3-Clause",
   "keywords": [


### PR DESCRIPTION
This handles and closes #167, it also resolves #169 

To sum things up this filter text-indent based on the selectors from text-align by attempting to filter out paragraphs which are part of an explicit or implicit header. 

It also filters out hyperlinks for underline normalization.

No version bump as another PR for experimental web pub is coming.