### PR TITLE
Indent fix for webkit

### DIFF
--- a/css/dist/ReadiumCSS-after.css
+++ b/css/dist/ReadiumCSS-after.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0
+ * Readium CSS v.2.0.1
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.
@@ -362,8 +362,7 @@ body{
   text-indent:var(--USER__paraIndent) !important;
 }
 
-:root[style*="--USER__paraIndent"] p *,
-:root[style*="--USER__paraIndent"] p:first-letter{
+:root[style*="--USER__paraIndent"] p *{
   text-indent:0 !important;
 }
 

--- a/css/dist/ReadiumCSS-before.css
+++ b/css/dist/ReadiumCSS-before.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0
+ * Readium CSS v.2.0.1
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/ReadiumCSS-default.css
+++ b/css/dist/ReadiumCSS-default.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0
+ * Readium CSS v.2.0.1
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/cjk-horizontal/ReadiumCSS-after.css
+++ b/css/dist/cjk-horizontal/ReadiumCSS-after.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0
+ * Readium CSS v.2.0.1
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/cjk-horizontal/ReadiumCSS-before.css
+++ b/css/dist/cjk-horizontal/ReadiumCSS-before.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0
+ * Readium CSS v.2.0.1
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/cjk-horizontal/ReadiumCSS-default.css
+++ b/css/dist/cjk-horizontal/ReadiumCSS-default.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0
+ * Readium CSS v.2.0.1
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/cjk-vertical/ReadiumCSS-after.css
+++ b/css/dist/cjk-vertical/ReadiumCSS-after.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0
+ * Readium CSS v.2.0.1
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/cjk-vertical/ReadiumCSS-before.css
+++ b/css/dist/cjk-vertical/ReadiumCSS-before.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0
+ * Readium CSS v.2.0.1
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/cjk-vertical/ReadiumCSS-default.css
+++ b/css/dist/cjk-vertical/ReadiumCSS-default.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0
+ * Readium CSS v.2.0.1
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/rtl/ReadiumCSS-after.css
+++ b/css/dist/rtl/ReadiumCSS-after.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0
+ * Readium CSS v.2.0.1
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.
@@ -315,8 +315,7 @@ body{
   text-indent:var(--USER__paraIndent) !important;
 }
 
-:root[style*="--USER__paraIndent"] p *,
-:root[style*="--USER__paraIndent"] p:first-letter{
+:root[style*="--USER__paraIndent"] p *{
   text-indent:0 !important;
 }
 

--- a/css/dist/rtl/ReadiumCSS-before.css
+++ b/css/dist/rtl/ReadiumCSS-before.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0
+ * Readium CSS v.2.0.1
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/rtl/ReadiumCSS-default.css
+++ b/css/dist/rtl/ReadiumCSS-default.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0
+ * Readium CSS v.2.0.1
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/webPub/ReadiumCSS-webPub.css
+++ b/css/dist/webPub/ReadiumCSS-webPub.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.0
+ * Readium CSS v.2.0.1
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.
@@ -152,8 +152,7 @@
   text-indent:var(--USER__paraIndent) !important;
 }
 
-:root[style*="--USER__paraIndent"] p *,
-:root[style*="--USER__paraIndent"] p:first-letter{
+:root[style*="--USER__paraIndent"] p *{
   text-indent:0 !important;
 }
 

--- a/css/src/modules/user-settings-submodules/ReadiumCSS-paraIndent_pref.css
+++ b/css/src/modules/user-settings-submodules/ReadiumCSS-paraIndent_pref.css
@@ -20,7 +20,6 @@
 
 /* If there are inline-block elements in paragraphs, text-indent will inherit so we must reset it */
 
-:root[style*="--USER__paraIndent"] p *,
-:root[style*="--USER__paraIndent"] p:first-letter {
+:root[style*="--USER__paraIndent"] p * {
   text-indent: 0 !important;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@readium/css",
   "description": "A set of reference stylesheets for EPUB Reading Systems",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "https://github.com/readium/css",
   "license": "BSD-3-Clause",
   "keywords": [


### PR DESCRIPTION
This removes `: first-letter` from the paragraph indent submodule. 

See https://github.com/readium/swift-toolkit/issues/721 for more details