### PR TITLE
Patch settings inheritance

### DIFF
--- a/css/dist/ReadiumCSS-after.css
+++ b/css/dist/ReadiumCSS-after.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.1
+ * Readium CSS v.2.0.2
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.
@@ -247,11 +247,11 @@ body{
 :root[style*="--USER__bodyHyphens"] li,
 :root[style*="--USER__bodyHyphens"] div,
 :root[style*="--USER__bodyHyphens"] dd{
-  -webkit-hyphens:inherit;
-  -moz-hyphens:inherit;
-  -ms-hyphens:inherit;
-  -epub-hyphens:inherit;
-  hyphens:inherit;
+  -webkit-hyphens:var(--USER__bodyHyphens) !important;
+  -moz-hyphens:var(--USER__bodyHyphens) !important;
+  -ms-hyphens:var(--USER__bodyHyphens) !important;
+  -epub-hyphens:var(--USER__bodyHyphens) !important;
+  hyphens:var(--USER__bodyHyphens) !important;
 }
 
 :root[style*="--USER__fontFamily"]{
@@ -342,7 +342,7 @@ body{
 :root[style*="--USER__lineHeight"] p,
 :root[style*="--USER__lineHeight"] li,
 :root[style*="--USER__lineHeight"] div{
-  line-height:inherit;
+  line-height:var(--USER__lineHeight) !important;
 }
 
 :root[style*="--USER__paraSpacing"] p{
@@ -377,7 +377,7 @@ body{
 :root[style*="--USER__wordSpacing"] div,
 :root[style*="--USER__wordSpacing"] dt,
 :root[style*="--USER__wordSpacing"] dd{
-  word-spacing:var(--USER__wordSpacing);
+  word-spacing:var(--USER__wordSpacing) !important;
 }
 
 :root[style*="--USER__letterSpacing"] h1,
@@ -391,8 +391,8 @@ body{
 :root[style*="--USER__letterSpacing"] div,
 :root[style*="--USER__letterSpacing"] dt,
 :root[style*="--USER__letterSpacing"] dd{
-  letter-spacing:var(--USER__letterSpacing);
-  font-variant:none;
+  letter-spacing:var(--USER__letterSpacing) !important;
+  font-variant:none !important;
 }
 
 :root[style*="--USER__ligatures"]{

--- a/css/dist/ReadiumCSS-before.css
+++ b/css/dist/ReadiumCSS-before.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.1
+ * Readium CSS v.2.0.2
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/ReadiumCSS-default.css
+++ b/css/dist/ReadiumCSS-default.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.1
+ * Readium CSS v.2.0.2
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/cjk-horizontal/ReadiumCSS-after.css
+++ b/css/dist/cjk-horizontal/ReadiumCSS-after.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.1
+ * Readium CSS v.2.0.2
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.
@@ -273,7 +273,7 @@ body{
 :root[style*="--USER__lineHeight"] p,
 :root[style*="--USER__lineHeight"] li,
 :root[style*="--USER__lineHeight"] div{
-  line-height:inherit;
+  line-height:var(--USER__lineHeight) !important;
 }
 
 :root[style*="--USER__paraSpacing"] p{
@@ -309,8 +309,8 @@ body{
 :root[style*="--USER__letterSpacing"] div,
 :root[style*="--USER__letterSpacing"] dt,
 :root[style*="--USER__letterSpacing"] dd{
-  letter-spacing:var(--USER__letterSpacing);
-  font-variant:none;
+  letter-spacing:var(--USER__letterSpacing) !important;
+  font-variant:none !important;
 }
 
 :root[style*="readium-noRuby-on"] body rt,

--- a/css/dist/cjk-horizontal/ReadiumCSS-before.css
+++ b/css/dist/cjk-horizontal/ReadiumCSS-before.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.1
+ * Readium CSS v.2.0.2
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/cjk-horizontal/ReadiumCSS-default.css
+++ b/css/dist/cjk-horizontal/ReadiumCSS-default.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.1
+ * Readium CSS v.2.0.2
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/cjk-vertical/ReadiumCSS-after.css
+++ b/css/dist/cjk-vertical/ReadiumCSS-after.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.1
+ * Readium CSS v.2.0.2
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.
@@ -258,7 +258,7 @@ body{
 :root[style*="--USER__lineHeight"] p,
 :root[style*="--USER__lineHeight"] li,
 :root[style*="--USER__lineHeight"] div{
-  line-height:inherit;
+  line-height:var(--USER__lineHeight) !important;
 }
 
 :root[style*="--USER__paraSpacing"] p{
@@ -294,8 +294,8 @@ body{
 :root[style*="--USER__letterSpacing"] div,
 :root[style*="--USER__letterSpacing"] dt,
 :root[style*="--USER__letterSpacing"] dd{
-  letter-spacing:var(--USER__letterSpacing);
-  font-variant:none;
+  letter-spacing:var(--USER__letterSpacing) !important;
+  font-variant:none !important;
 }
 
 :root[style*="readium-noRuby-on"] body rt,

--- a/css/dist/cjk-vertical/ReadiumCSS-before.css
+++ b/css/dist/cjk-vertical/ReadiumCSS-before.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.1
+ * Readium CSS v.2.0.2
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/cjk-vertical/ReadiumCSS-default.css
+++ b/css/dist/cjk-vertical/ReadiumCSS-default.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.1
+ * Readium CSS v.2.0.2
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/rtl/ReadiumCSS-after.css
+++ b/css/dist/rtl/ReadiumCSS-after.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.1
+ * Readium CSS v.2.0.2
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.
@@ -295,7 +295,7 @@ body{
 :root[style*="--USER__lineHeight"] p,
 :root[style*="--USER__lineHeight"] li,
 :root[style*="--USER__lineHeight"] div{
-  line-height:inherit;
+  line-height:var(--USER__lineHeight) !important;
 }
 
 :root[style*="--USER__paraSpacing"] p{
@@ -330,7 +330,7 @@ body{
 :root[style*="--USER__wordSpacing"] div,
 :root[style*="--USER__wordSpacing"] dt,
 :root[style*="--USER__wordSpacing"] dd{
-  word-spacing:var(--USER__wordSpacing);
+  word-spacing:var(--USER__wordSpacing) !important;
 }
 
 :root[style*="--USER__ligatures"]{

--- a/css/dist/rtl/ReadiumCSS-before.css
+++ b/css/dist/rtl/ReadiumCSS-before.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.1
+ * Readium CSS v.2.0.2
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/rtl/ReadiumCSS-default.css
+++ b/css/dist/rtl/ReadiumCSS-default.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.1
+ * Readium CSS v.2.0.2
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.

--- a/css/dist/webPub/ReadiumCSS-webPub.css
+++ b/css/dist/webPub/ReadiumCSS-webPub.css
@@ -1,5 +1,5 @@
 /*!
- * Readium CSS v.2.0.1
+ * Readium CSS v.2.0.2
  * Copyright (c) 2017–2026. Readium Foundation. All rights reserved.
  * Use of this source code is governed by a BSD-style license which is detailed in the
  * LICENSE file present in the project repository where this source code is maintained.
@@ -48,11 +48,11 @@
 :root[style*="--USER__bodyHyphens"] li,
 :root[style*="--USER__bodyHyphens"] div,
 :root[style*="--USER__bodyHyphens"] dd{
-  -webkit-hyphens:inherit;
-  -moz-hyphens:inherit;
-  -ms-hyphens:inherit;
-  -epub-hyphens:inherit;
-  hyphens:inherit;
+  -webkit-hyphens:var(--USER__bodyHyphens) !important;
+  -moz-hyphens:var(--USER__bodyHyphens) !important;
+  -ms-hyphens:var(--USER__bodyHyphens) !important;
+  -epub-hyphens:var(--USER__bodyHyphens) !important;
+  hyphens:var(--USER__bodyHyphens) !important;
 }
 
 :root[style*="--USER__fontFamily"]{
@@ -132,7 +132,7 @@
 :root[style*="--USER__lineHeight"] p,
 :root[style*="--USER__lineHeight"] li,
 :root[style*="--USER__lineHeight"] div{
-  line-height:inherit;
+  line-height:var(--USER__lineHeight) !important;
 }
 
 :root[style*="--USER__paraSpacing"] p{
@@ -167,7 +167,7 @@
 :root[style*="--USER__wordSpacing"] div,
 :root[style*="--USER__wordSpacing"] dt,
 :root[style*="--USER__wordSpacing"] dd{
-  word-spacing:var(--USER__wordSpacing);
+  word-spacing:var(--USER__wordSpacing) !important;
 }
 
 :root[style*="--USER__letterSpacing"] h1,
@@ -181,8 +181,8 @@
 :root[style*="--USER__letterSpacing"] div,
 :root[style*="--USER__letterSpacing"] dt,
 :root[style*="--USER__letterSpacing"] dd{
-  letter-spacing:var(--USER__letterSpacing);
-  font-variant:none;
+  letter-spacing:var(--USER__letterSpacing) !important;
+  font-variant:none !important;
 }
 
 :root[style*="--USER__fontWeight"] body{

--- a/css/src/modules/user-settings-submodules/ReadiumCSS-bodyHyphens_pref.css
+++ b/css/src/modules/user-settings-submodules/ReadiumCSS-bodyHyphens_pref.css
@@ -16,15 +16,14 @@
   hyphens: var(--USER__bodyHyphens) !important;
 }
 
-/* Sorry, we can’t use `:matches`, `:-moz-any` or `:-webkit-any` because MS doesn’t support it yet */
 :root[style*="--USER__bodyHyphens"] body,
 :root[style*="--USER__bodyHyphens"] p,
 :root[style*="--USER__bodyHyphens"] li,
 :root[style*="--USER__bodyHyphens"] div,
 :root[style*="--USER__bodyHyphens"] dd {
-  -webkit-hyphens: inherit;
-  -moz-hyphens: inherit;
-  -ms-hyphens: inherit;
-  -epub-hyphens: inherit;
-  hyphens: inherit;
+  -webkit-hyphens: var(--USER__bodyHyphens) !important;
+  -moz-hyphens: var(--USER__bodyHyphens) !important;
+  -ms-hyphens: var(--USER__bodyHyphens) !important;
+  -epub-hyphens: var(--USER__bodyHyphens) !important;
+  hyphens: var(--USER__bodyHyphens) !important;
 }

--- a/css/src/modules/user-settings-submodules/ReadiumCSS-letterSpacing_pref.css
+++ b/css/src/modules/user-settings-submodules/ReadiumCSS-letterSpacing_pref.css
@@ -17,6 +17,6 @@
 :root[style*="--USER__letterSpacing"] div,
 :root[style*="--USER__letterSpacing"] dt,
 :root[style*="--USER__letterSpacing"] dd {
-  letter-spacing: var(--USER__letterSpacing);
-  font-variant: none;
+  letter-spacing: var(--USER__letterSpacing) !important;
+  font-variant: none !important;
 }

--- a/css/src/modules/user-settings-submodules/ReadiumCSS-lineHeight_pref.css
+++ b/css/src/modules/user-settings-submodules/ReadiumCSS-lineHeight_pref.css
@@ -14,5 +14,5 @@
 :root[style*="--USER__lineHeight"] p,
 :root[style*="--USER__lineHeight"] li,
 :root[style*="--USER__lineHeight"] div {
-  line-height: inherit;
+  line-height: var(--USER__lineHeight) !important;
 }

--- a/css/src/modules/user-settings-submodules/ReadiumCSS-wordSpacing_pref.css
+++ b/css/src/modules/user-settings-submodules/ReadiumCSS-wordSpacing_pref.css
@@ -17,5 +17,5 @@
 :root[style*="--USER__wordSpacing"] div,
 :root[style*="--USER__wordSpacing"] dt,
 :root[style*="--USER__wordSpacing"] dd {
-  word-spacing: var(--USER__wordSpacing);
+  word-spacing: var(--USER__wordSpacing) !important;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@readium/css",
   "description": "A set of reference stylesheets for EPUB Reading Systems",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "homepage": "https://github.com/readium/css",
   "license": "BSD-3-Clause",
   "keywords": [


### PR DESCRIPTION
This is meant to protect some settings against intermediate elements declaring a user setting style. 

Previously hyphens and line-height were inherited from `body`, which failed when a `section` or `div` was declaring them because the element e.g. `p`, `li` would then inherit from this value, and not the user setting. Now, they set the `var` directly, like text-align.

Letter and word-spacing were also missing `!important`. 